### PR TITLE
fix(teleport-bin): LICENSE-community file has been moved

### DIFF
--- a/teleport-bin/PKGBUILD
+++ b/teleport-bin/PKGBUILD
@@ -7,7 +7,7 @@
 _pkgname=teleport
 pkgname=teleport-bin
 pkgver=17.0.5
-pkgrel=1
+pkgrel=2
 pkgdesc="Modern SSH server for teams managing distributed infrastructure"
 arch=('i386' 'x86_64' 'armv7h' 'aarch64')
 url="https://goteleport.com/"
@@ -22,7 +22,7 @@ install=teleport.install
 source=("teleport.service"
         "teleport@.service"
         "teleport.install"
-        "LICENSE-community::https://raw.githubusercontent.com/gravitational/teleport/master/LICENSE-community")
+        "LICENSE-community::https://raw.githubusercontent.com/gravitational/teleport/master/build.assets/LICENSE-community")
 
 # The teleport servers do not allow for byte ranges to continue download so we set -C0
 # https://aur.archlinux.org/packages/teleport-bin#comment-906339
@@ -36,7 +36,7 @@ source_aarch64=("teleport-bin-${pkgver}-aarch64.tar.gz::https://get.gravitationa
 sha256sums=('b7ac1b9fa9788989b9cef9e555b278635faa4be8350a959580f19076241cde85'
             'b7aa05eeb0d39875481c56bc21edf60a5bd7184bc5c424df68a5d4eb2b2882f1'
             'c71bbe70179aceb0f49d2a4f1e0a83da040ca72373e17ca82cc2489cd6e07801'
-            'a45b5a4bdfe894ebd901568b29517fe3d8342d49f1f394feb62a8dc8fe233dda')
+            '3beda963b864fc67546e6926fd6ee8601cafee44a9d24440042efd68b7cab8f6')
 sha256sums_i386=('2ff523b27a4dbe80272efcbcc01a06010b9ec23cfced5180b7df1b3afd2d59ff')
 sha256sums_x86_64=('9cc6a7439a67e9dd67af57d5580d5cd98636c8f390d659c7df750c265e3e6a81')
 sha256sums_armv7h=('15b10af32e6dcf51711aeb0b8326a9dfc9e07fc9fb0f1081c8fc63058cce2d1e')


### PR DESCRIPTION
The LICENSE-community file of the teleport-bin package has been moved, it is currently not possible to build the package without modification. See commit: https://github.com/gravitational/teleport/commit/de8133d66da36b8b3e5c8d71177b3ce2a27df593